### PR TITLE
add current_revision as an attribute to GerritChange

### DIFF
--- a/gerrit/changes/change.py
+++ b/gerrit/changes/change.py
@@ -26,6 +26,7 @@ class GerritChange(BaseModel):
             "mergeable",
             "insertions",
             "deletions",
+            "current_revision",
             "_number",
             "owner",
             "gerrit",


### PR DESCRIPTION
This way when the search criteria contains `&o=current_revision` that attribute is set.