### PR TITLE
Fix for projects with parent

### DIFF
--- a/gerrit/projects/projects.py
+++ b/gerrit/projects/projects.py
@@ -3,6 +3,10 @@
 # @Author: Jialiang Shi
 from gerrit.projects.project import GerritProject
 
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus
 
 class GerritProjects(object):
     def __init__(self, gerrit):
@@ -46,7 +50,7 @@ class GerritProjects(object):
         :param project_name: the name of the project
         :return:
         """
-        endpoint = "/projects/%s" % project_name
+        endpoint = "/projects/%s" % quote_plus(project_name)
         response = self.gerrit.requester.get(self.gerrit.get_endpoint_url(endpoint))
         result = self.gerrit.decode_response(response)
         return GerritProject.parse(result, gerrit=self.gerrit)
@@ -72,7 +76,7 @@ class GerritProjects(object):
 
         :return:
         """
-        endpoint = "/projects/%s" % project_name
+        endpoint = "/projects/%s" % quote(project_name)
         base_url = self.gerrit.get_endpoint_url(endpoint)
         response = self.gerrit.requester.put(
             base_url, json=input_, headers=self.gerrit.default_headers
@@ -87,5 +91,5 @@ class GerritProjects(object):
         :param project_name: project name
         :return:
         """
-        endpoint = "/projects/%s/delete-project~delete" % project_name
+        endpoint = "/projects/%s/delete-project~delete" % quote(project_name)
         self.gerrit.requester.post(self.gerrit.get_endpoint_url(endpoint))


### PR DESCRIPTION
The project name was used instead of the project id which is the
encoded version.

#3