### PR TITLE
Add regex project endpoint

### DIFF
--- a/gerrit/changes/change.py
+++ b/gerrit/changes/change.py
@@ -363,6 +363,40 @@ class GerritChange(BaseModel):
         result = self.gerrit.decode_response(response)
         return self.gerrit.changes.get(result.get("id"))
 
+    def stage(self):
+        """
+        Stages a change in the Qt CI.
+
+        If the change cannot be staged because the QtStage rule doesn't allow staging the change,
+        the response is 409 Conflict and the error message is contained in the response body.
+
+        .. code-block:: python
+            change = gerrit.changes.get('myProject~stable~I10394472cbd17dd12454f229e4f6de00b143a444')
+            result = change.stage()
+        """
+        endpoint = "/changes/%s/revisions/current/gerrit-plugin-qt-workflow~stage" % self.id
+        base_url = self.gerrit.get_endpoint_url(endpoint)
+        response = self.gerrit.requester.post(
+            base_url
+        )
+        result = self.gerrit.decode_response(response)
+        return not result
+
+    def unstage(self):
+        """
+        Unstages a change in the Qt CI.
+
+        If the change cannot be unstaged because the change is not currently staged,
+        the response is 409 Conflict and the error message is contained in the response body.
+        """
+        endpoint = "/changes/%s/revisions/current/gerrit-plugin-qt-workflow~unstage" % self.id
+        base_url = self.gerrit.get_endpoint_url(endpoint)
+        response = self.gerrit.requester.post(
+            base_url
+        )
+        result = self.gerrit.decode_response(response)
+        return not result
+
     def delete(self):
         """
         Deletes a change.

--- a/gerrit/projects/projects.py
+++ b/gerrit/projects/projects.py
@@ -45,15 +45,15 @@ class GerritProjects(object):
 
     def regex(self, query):
         """
-        Regex queries projects visible to the caller.
-        The query string must be provided by the query parameter.
+        Queries projects visible to the caller. The query string must be provided by the query parameter.
         The start and limit parameters can be used to skip/limit results.
 
         query parameter
-         * Boundary matchers '^' and '$' are implicit.
-         * For example: the regex 'test.*' will match any projects that start with 'test' and regex
-           '.*test' will match any project that end with 'test'.
-         * The match is case sensitive.
+          * name:'NAME' Matches projects that have exactly the name 'NAME'.
+          * parent:'PARENT' Matches projects that have 'PARENT' as parent project.
+          * inname:'NAME' Matches projects that a name part that starts with 'NAME' (case insensitive).
+          * description:'DESCRIPTION' Matches projects whose description contains 'DESCRIPTION', using a full-text search.
+          * state:'STATE' Matches project’s state. Can be either 'active' or 'read-only'.
 
         :param query:
         :return:

--- a/gerrit/projects/projects.py
+++ b/gerrit/projects/projects.py
@@ -43,6 +43,26 @@ class GerritProjects(object):
         result = self.gerrit.decode_response(response)
         return GerritProject.parse_list(result, gerrit=self.gerrit)
 
+    def regex(self, query):
+        """
+        Regex queries projects visible to the caller.
+        The query string must be provided by the query parameter.
+        The start and limit parameters can be used to skip/limit results.
+
+        query parameter
+         * Boundary matchers '^' and '$' are implicit.
+         * For example: the regex 'test.*' will match any projects that start with 'test' and regex
+           '.*test' will match any project that end with 'test'.
+         * The match is case sensitive.
+
+        :param query:
+        :return:
+        """
+        endpoint = "/projects/?r=%s" % query
+        response = self.gerrit.requester.get(self.gerrit.get_endpoint_url(endpoint))
+        result = self.gerrit.decode_response(response)
+        return GerritProject.parse_dict(result, gerrit=self.gerrit)
+
     def get(self, project_name):
         """
         Retrieves a project.

--- a/gerrit/utils/models.py
+++ b/gerrit/utils/models.py
@@ -41,7 +41,7 @@ class BaseModel(object):
 
     @classmethod
     def parse_dict(cls, data, **kwargs):
-        """Parse a dict of JSON objects into a result set of model instances."""
+        """Parse a list of JSON objects into a result set of model instances."""
         results = ResultSet()
         data = data or []
         for obj in data.keys():

--- a/gerrit/utils/models.py
+++ b/gerrit/utils/models.py
@@ -39,6 +39,16 @@ class BaseModel(object):
                 results.append(cls.parse(obj, **kwargs))
         return results
 
+    @classmethod
+    def parse_dict(cls, data, **kwargs):
+        """Parse a dict of JSON objects into a result set of model instances."""
+        results = ResultSet()
+        data = data or []
+        for obj in data.keys():
+            if obj:
+                results.append(cls.parse(data[obj], **kwargs))
+        return results
+
     def __repr__(self):
         key = self.attributes[0]
         value = getattr(self, key)


### PR DESCRIPTION
Since the project query parameter is unable to search by regex,
add it explicity. This addition makes it easier to narrow down project
results where the regular query option "inname" is insufficient.