### PR TITLE
Add 'use_netrc' KWArg for GerritClient to support the netrc file for auth

### DIFF
--- a/gerrit/__init__.py
+++ b/gerrit/__init__.py
@@ -2,6 +2,7 @@
 # -*- coding:utf-8 -*-
 # @Author: Jialiang Shi
 import json
+import netrc
 from gerrit.utils.requester import Requester
 from gerrit.config.config import GerritConfig
 from gerrit.projects.projects import GerritProjects
@@ -24,13 +25,20 @@ class GerritClient(object):
         self,
         base_url,
         username,
-        password,
+        password=None,
+        use_netrc=False,
         ssl_verify=True,
         cert=None,
         timeout=60,
         max_retries=None,
     ):
+        if not password and not use_netrc:
+            raise ValueError("One of 'password' or 'use_netrc' parameter should be set!")
+
         self._base_url = self.strip_trailing_slash(base_url)
+
+        if not password and use_netrc:
+            password = self.get_password_from_netrc_file()
 
         self.requester = Requester(
             username=username,
@@ -40,6 +48,20 @@ class GerritClient(object):
             timeout=timeout,
             max_retries=max_retries,
         )
+
+    def get_password_from_netrc_file(self):
+        """
+        Providing the password form .netrc file for getting Host name.
+        :return: The related password from .netrc file as a string.
+        """
+
+        netrc_client = netrc.netrc()
+        auth_tokens = netrc_client.authenticators(self._base_url)
+        if not auth_tokens:
+            raise ValueError(
+                "The '{}' host name is not found in netrc file.".format(self._base_url)
+            )
+        return auth_tokens[2]
 
     @classmethod
     def strip_trailing_slash(cls, url):

--- a/gerrit/__init__.py
+++ b/gerrit/__init__.py
@@ -33,7 +33,7 @@ class GerritClient(object):
         max_retries=None,
     ):
         if not password and not use_netrc:
-            raise ValueError("One of 'password' or 'use_netrc' parameter should be set!")
+            raise ValueError("One of 'password' or 'use_netrc' parameters should be set!")
 
         self._base_url = self.strip_trailing_slash(base_url)
 


### PR DESCRIPTION
**Benefits of pull request:**
With this solution we don't need to use our password in the `GerritClient` class when we create an instance from it. If we set the `use_netrc` parameter to `True` (Default is `False`) then the `__init__` method of `GerritClient` tries to get the password for the host name (Of course in this case the password parameter is not mandatory).


**Error handling:**
If none of `use_netrc` and `passoword` paramters is set then the `GerritClient` raises a `ValueError` exception and notify the user to set one of the parameters.
If the both of  `use_netrc` and `passoword` paramters are set then the `GerritClient` will use the `passoword`

**Backward compatibility:**
The change is totally backward compatible and doesn't hurt the legacy code.

**I see one more possible improvement:**

- If we check the type of `use_netrc` parameter and if it's a `string`/`PathLike` object then it should be passed as a parameter to `netrc.netrc()` inside `get_password_from_netrc_file` method and with this improvement the user can use different netrc files for AUTH. Reference: https://docs.python.org/3/library/netrc.html#netrc.netrc