### PR TITLE
Catch AttributeError when getting changes with detail

### DIFF
--- a/gerrit/utils/models.py
+++ b/gerrit/utils/models.py
@@ -32,7 +32,10 @@ class BaseModel(object):
         data.update(kwargs)
 
         for key, value in data.items():
-            setattr(item, key, value)
+            try:
+                setattr(item, key, value)
+            except AttributeError:
+                pass
 
         return item
 


### PR DESCRIPTION
When getting a detail info about a change, the setattr() throws an
exception:
```
change = client.changes.get(68, detailed=True)
Traceback (most recent call last):
  ...
  File "python-gerrit-api/gerrit/changes/changes.py", line 64, in get
    return GerritChange.parse(result, gerrit=self.gerrit)
  File "python-gerrit-api/gerrit/utils/models.py", line 35, in parse
    setattr(item, key, value)
AttributeError: can't set attribute 'reviewers'
```
It happens, because `reviewers` is a readonly @property.  Same problem
occurrs for `messages`.

Signed-off-by: Konrad Sztyber <konrad.sztyber@gmail.com>