### PR TITLE
Update the query parameter description

### DIFF
--- a/gerrit/changes/changes.py
+++ b/gerrit/changes/changes.py
@@ -18,7 +18,8 @@ class GerritChanges(object):
             query = "is:open+owner:self+is:mergeable"
             result = client.changes.search(query=query, options=["LABELS"])
 
-        :param query: Queries as a list of string
+        :param query: Query string, it can contain multiple search operators
+                      concatenated by '+' character
         :param options: List of options to fetch additional data about changes
         :param limit: Int value that allows to limit the number of changes
                       to be included in the output results


### PR DESCRIPTION
The description of the query parameter needs to be updated as it is no longer a List after the following changes: https://github.com/shijl0925/python-gerrit-api/commit/a7893d9dd9fd8548eb1ac44ec49286be4f4d680e

I used the term "search operators" as it is used by Gerrit API here: https://gerrit-review.googlesource.com/Documentation/user-search.html#_search_operators