### PR TITLE
fix: load username from netrc when use_netrc=True

### DIFF
--- a/gerrit/base.py
+++ b/gerrit/base.py
@@ -43,7 +43,7 @@ class GerritClient:
             session = requests.Session()
 
         if use_netrc:
-            password = self.get_password_from_netrc_file()
+            username, password = self.get_password_from_netrc_file()
 
         if username and password:
             session.auth = (username, password)
@@ -89,7 +89,8 @@ class GerritClient:
             raise ValueError(
                 f"The '{self._base_url}' host name is not found in netrc file."
             )
-        return auth_tokens[2]
+        login, _, password = auth_tokens
+        return login, password
 
     def get_endpoint_url(self, endpoint: str) -> str:
         """

--- a/tests/test_gerrit_client.py
+++ b/tests/test_gerrit_client.py
@@ -265,8 +265,8 @@ class TestGetPasswordFromNetrc:
             MockNetrc.return_value = mock_netrc
 
             basic_client._base_url = "gerrit.example.com"
-            password = basic_client.get_password_from_netrc_file()
-            assert password == "password123"
+            username, password = basic_client.get_password_from_netrc_file()
+            assert username == "user" and password == "password123"
 
     def test_host_not_found_raises(self, basic_client):
         with patch("gerrit.base.netrc.netrc") as MockNetrc:


### PR DESCRIPTION
## **User description**
Currently, username is not read from the netrc, when it is expected to be there if the credentials for Gerrit are properly configured.

## Summary by Sourcery

当启用 `use_netrc` 时，从 netrc 文件中同时加载用户名和密码，以便 Gerrit 会话能够正确完成身份验证。

Bug Fixes:
- 在初始化 Gerrit 客户端时，确保从 netrc 条目中与密码一起读取用户名。

Tests:
- 扩展 Gerrit 客户端的 netrc 测试，用于断言用户名能够从 netrc 文件中被正确加载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Load both username and password from the netrc file when use_netrc is enabled so Gerrit sessions can authenticate correctly.

Bug Fixes:
- Ensure username is read from the netrc entry alongside the password when initializing the Gerrit client.

Tests:
- Extend Gerrit client netrc tests to assert that the username is correctly loaded from the netrc file.

</details>


___

## **CodeAnt-AI Description**
**Load username and password from netrc for Gerrit sign-in**

### What Changed
- When `use_netrc` is enabled, Gerrit now uses both the username and password saved in `.netrc` instead of only the password.
- This lets Gerrit sessions authenticate correctly when credentials are stored in netrc.
- The netrc test now checks that the username is loaded as well as the password.

### Impact
`✅ Fewer failed Gerrit logins`
`✅ Correct sign-in with netrc credentials`
`✅ Clearer netrc authentication behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
