### PR TITLE
fix: strip protocol when looking hostname in netrc

### DIFF
--- a/gerrit/base.py
+++ b/gerrit/base.py
@@ -8,7 +8,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests import Session
 from gerrit.utils.requester import Requester
-from gerrit.utils.common import decode_response, strip_trailing_slash
+from gerrit.utils.common import decode_response, strip_trailing_slash, strip_protocol
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,8 @@ class GerritClient:
         """
 
         netrc_client = netrc.netrc()
-        auth_tokens = netrc_client.authenticators(self._base_url)
+        hostname = strip_protocol(self._base_url)
+        auth_tokens = netrc_client.authenticators(hostname)
         if not auth_tokens:
             raise ValueError(
                 f"The '{self._base_url}' host name is not found in netrc file."

--- a/gerrit/utils/common.py
+++ b/gerrit/utils/common.py
@@ -16,6 +16,17 @@ def strip_trailing_slash(url: str) -> str:
     return url
 
 
+def strip_protocol(url: str) -> str:
+    """
+    remove url's leading protocol
+    :param url: url
+    :return: url without leading protocol
+    """
+    if "://" in url:
+        url = url.split("://", maxsplit=1)[1]
+    return url
+
+
 def decode_response(response: Any) -> Any:
     """Strip off Gerrit's magic prefix and decode a response.
     :returns:

--- a/tests/test_gerrit_client.py
+++ b/tests/test_gerrit_client.py
@@ -268,6 +268,21 @@ class TestGetPasswordFromNetrc:
             password = basic_client.get_password_from_netrc_file()
             assert password == "password123"
 
+    def test_host_found_in_netrc_stripping_protocol(self, basic_client):
+        with patch("gerrit.base.netrc.netrc") as MockNetrc:
+            mock_netrc = MagicMock()
+            # Return password only for gerrit.example.com, not any host
+            mock_netrc.authenticators.side_effect = (
+                lambda host: ("user", "account", "password123")
+                if host == "gerrit.example.com"
+                else None
+            )
+            MockNetrc.return_value = mock_netrc
+
+            basic_client._base_url = "https://gerrit.example.com"
+            password = basic_client.get_password_from_netrc_file()
+            assert password == "password123"
+
     def test_host_not_found_raises(self, basic_client):
         with patch("gerrit.base.netrc.netrc") as MockNetrc:
             mock_netrc = MagicMock()


### PR DESCRIPTION
## **User description**
Currently, GerritClient works well when base_url has a protocol (i.e. https://), but when looking into a .netrc file, only the hosname may be used. With this patch, it is now possible to have https:// in `base_url` and set `use_netrc=True`.

## Summary by Sourcery

在 Gerrit 基础 URL 包含协议时，正确处理 .netrc 认证查找。

Bug 修复：
- 在 GerritClient 中，从 URL 中移除协议后再在 .netrc 中查找主机条目。
- 确保当 base_url 包含 `https://` 时，基于 netrc 的认证可以正常工作。
- 修复 GerritClient 的 netrc 查找，使其在匹配主机时同时返回用户名和密码。

增强：
- 添加 `strip_protocol` 工具方法，以复用移除协议的逻辑。

测试：
- 添加一个测试，用于验证当 base_url 包含协议时，.netrc 主机查找能够正常工作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle .netrc authentication lookups correctly when Gerrit base URLs include a protocol.

Bug Fixes:
- Strip URL protocols before looking up host entries in .netrc for GerritClient.
- Ensure netrc-based authentication works when base_url includes https://.
- Fix GerritClient netrc lookup to return username as well as password when matching hosts.

Enhancements:
- Add a strip_protocol utility helper for reusing protocol-stripping logic.

Tests:
- Add a test verifying .netrc host lookup works when base_url contains a protocol.

</details>


___

## **CodeAnt-AI Description**
**Allow netrc login when the server URL includes a protocol**

### What Changed
- Netrc lookups now use just the hostname, so credentials can be found even when the server is set as `https://...`
- If the host is not present in `.netrc`, the client still raises a clear error
- Added coverage for both plain hostnames and protocol-prefixed URLs

### Impact
`✅ Fewer netrc login failures`
`✅ Works with https:// server URLs`
`✅ Clearer credential lookup behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
